### PR TITLE
fix: use localStorage instead of sessionStorage

### DIFF
--- a/src/api/LoginApi.tsx
+++ b/src/api/LoginApi.tsx
@@ -11,8 +11,10 @@ export default class LoginApi {
 
         const response: ILoginResponse = res.data;
         if (response.httpStatusCode === HttpStatusCodes.SUCCESS) {
-            window.sessionStorage.setItem(Constants.namespace + '_userUuid', response.data?.uuid as string);
-            window.sessionStorage.setItem(Constants.namespace + '_userName', response.data?.name as string);
+            window.localStorage.setItem(Constants.namespace + '_userUuid', response.data?.uuid as string);
+            window.localStorage.setItem(Constants.namespace + '_userName', response.data?.name as string);
+            Constants.userUuid = window.localStorage.getItem(Constants.namespace + '_userUuid') as string;
+            
             return true;
         }
         else {

--- a/src/api/TripApi.tsx
+++ b/src/api/TripApi.tsx
@@ -5,7 +5,7 @@ import { IAddTripResponse, ITripData, ITripDetails, ITripResponse } from "../mod
 
 export default class TripApi {
     public async getTripsByUserUuid(userUuid: string): Promise<ITripData[]> {
-        const res = await axios.get(Constants.baseUrl + '/users/'+ userUuid +'/trips');
+        const res = await axios.get(Constants.baseUrl + '/users/'+ userUuid +'/trips')
         const response: ITripResponse = res.data;
 
         if (response.httpStatusCode === HttpStatusCodes.SUCCESS) {

--- a/src/helpers/LoginHelper.tsx
+++ b/src/helpers/LoginHelper.tsx
@@ -2,7 +2,7 @@ import Constants from "../models/Constants"
 
 export default class LoginHelper {
     public static checkSession = (): boolean => {
-        if (window.sessionStorage.getItem(Constants.namespace + '_userUuid') && window.sessionStorage.getItem(Constants.namespace + '_userName')) {
+        if (window.localStorage.getItem(Constants.namespace + '_userUuid') && window.localStorage.getItem(Constants.namespace + '_userName')) {
             return true;
         }
 

--- a/src/helpers/Navigator.tsx
+++ b/src/helpers/Navigator.tsx
@@ -16,8 +16,8 @@ export default class NavigationHelper {
     }
 
     public logout = () => {
-        window.sessionStorage.removeItem(Constants.namespace + '_userUuid');
-        window.sessionStorage.removeItem(Constants.namespace + '_userName');
+        window.localStorage.removeItem(Constants.namespace + '_userUuid');
+        window.localStorage.removeItem(Constants.namespace + '_userName');
         this.commonNavigator('/');
     }
 }

--- a/src/helpers/TripHelper.tsx
+++ b/src/helpers/TripHelper.tsx
@@ -1,7 +1,7 @@
 import Constants from "../models/Constants";
 
 export default class TripHelper {
-    private userUuid: string = window.sessionStorage.getItem(Constants.namespace + '_userUuid') as string;
+    private userUuid: string = window.localStorage.getItem(Constants.namespace + '_userUuid') as string;
 
     public getTripsByUserUuid = () => {
         

--- a/src/models/Constants.tsx
+++ b/src/models/Constants.tsx
@@ -1,6 +1,6 @@
 export default class Constants {
-    public static namespace: string = '_SP';
+public static namespace: string = '_SP';
     public static baseUrl: string = 'http://127.0.0.1:5000';
 
-    public static userUuid: string = window.sessionStorage.getItem(this.namespace + '_userUuid') as string;
+    public static userUuid: string = window.localStorage.getItem(this.namespace + '_userUuid') as string;
 }

--- a/src/views/DashboardPage.tsx
+++ b/src/views/DashboardPage.tsx
@@ -15,7 +15,7 @@ import NewTrip from '../components/NewTrip';
 const DashboardPage = () => {
     const navigator: NavigationHelper = new NavigationHelper();
     const tripApi: TripApi = new TripApi();
-    const userName: string = window.sessionStorage.getItem(Constants.namespace + '_userName') as string;
+    const userName: string = window.localStorage.getItem(Constants.namespace + '_userName') as string;
 
     const [trips, setTrips] = useState<ITripData[]>([]);
     const [isCreatingNewTrip, setIsCreatingNewTrip] = useState<boolean>(false);


### PR DESCRIPTION
closes #4 .

2 issues were identified while investigating this:

1. sessionStorage was being used instead of localStorage. This is an issue because sessionStorage only exists PER TAB. localStorage persists until the user clears cache or browser clears it.

2. this issue likely happened because ```Constants.userUuid``` was being passed in as a parameter, but at  that point in time it was likely not updated yet. Fix is to update the constant upon login.